### PR TITLE
Parsing - RateLaw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bionetgen/bng-*
 temp_testing/*
 .vscode/*
+test/models/cli_test_runs/*

--- a/bionetgen/modelapi/xmlparsers.py
+++ b/bionetgen/modelapi/xmlparsers.py
@@ -579,7 +579,7 @@ class RuleBlockXML(XMLObj):
             rate_cts = rate_cts_xml["RateConstant"]["@value"]
         elif rate_type == "Function":
             rate_cts = xml["@name"]
-        elif rate_type == "MM" or rate_type == "Sat":
+        elif rate_type == "MM" or rate_type == "Sat" or rate_type == "Hill":
             # A function type
             rate_cts = rate_type + "("
             args = xml["ListOfRateConstants"]["RateConstant"]

--- a/tests/models/hybrid_test.bngl
+++ b/tests/models/hybrid_test.bngl
@@ -30,10 +30,7 @@ begin observables
 	Species    R2       R==2
 	Species    R3       R==3
 	Species    R4       R==4
-  Species    R5g      R>4
-  Species    R5ge     R>=4
-  Species    R5l      R<4
-  Species    R5le     R<=4
+	Species    R5       R>4
 end observables
 begin reaction rules
 	R(l!1).L(r!1)          ->  R(l)  +  L(r)          koff

--- a/tests/models/test_Hill.bngl
+++ b/tests/models/test_Hill.bngl
@@ -1,0 +1,33 @@
+begin model
+begin parameters
+    # Kinetic constants
+    kcat  1
+    Km    1
+    # Hill coefficient?
+    Hc    2
+end parameters
+begin molecule types
+    E()
+    S()
+    P()
+end molecule types
+begin seed species
+    S()  100
+    E()  100
+    P()  0
+end seed species
+begin reaction rules 
+    S() + E() -> S() + E() + P()  Hill(kcat,Km,Hc)
+end reaction rules 
+begin observables
+    Molecules        St       S()
+    Molecules        Pt       P()
+    Molecules        Et       E()
+end observables
+end model
+
+## actions ##
+generate_network({overwrite=>1})
+simulate_ode({t_end=>5,n_steps=>20,atol=>1e-8,rtol=>1e-8,sparse=>1})
+resetConcentrations()
+writeNetwork({suffix=>"cont",evaluate_expressions=>0,overwrite=>1})


### PR DESCRIPTION
- ensured correct parsing of RateLaws in reaction rule blocks
     - added parsing of Hill RateLaw, as well as related testing file for pytest
     - Arrhenius RateLaw is not exported as XML by BNG, so it cannot be parsed here
-  added contents of cli_test_runs folder to .gitignore